### PR TITLE
Parameterize `parse_read` for custom UMI-tags etc.

### DIFF
--- a/demuxalot/snp_counter.py
+++ b/demuxalot/snp_counter.py
@@ -239,6 +239,7 @@ def count_call_variants_for_chromosome(
         parse_read,
         start=None,
         stop=None,
+        **kwargs
 ) -> Tuple[str, CompressedSNPCalls]:
     prev_segment = None
     compressed_snp_calls = CompressedSNPCalls()
@@ -248,7 +249,7 @@ def count_call_variants_for_chromosome(
         bamfile_or_filename = pysam.AlignmentFile(as_str(bamfile_or_filename))
 
     for read in bamfile_or_filename.fetch(chromosome, start=start, stop=stop):
-        parsed = parse_read(read)
+        parsed = parse_read(read, **kwargs)
         if parsed is None:
             continue
         cb = barcode_handler.get_barcode_index(read)
@@ -283,6 +284,7 @@ def count_snps(
         joblib_n_jobs=-1,
         joblib_verbosity=11,
         parse_read=parse_read,
+        **kwargs
 ) -> Dict[str, CompressedSNPCalls]:
     """
     Computes which molecules can provide information about SNPs
@@ -294,6 +296,7 @@ def count_snps(
     :param joblib_n_jobs: how many threads to run in parallel
     :param joblib_verbosity: verbosity level as interpreted by joblib
     :param parse_read: callback that checks if read should be discarded and parses necessary quantities
+    :param **kwargs: optional keyword arguments to pass down to parse_read callback
 
     see cellranger_specific.py for example of callbacks specific for cellranger
 
@@ -311,6 +314,7 @@ def count_snps(
                 stop=stop,
                 barcode_handler=barcode_handler,
                 parse_read=parse_read,
+                **kwargs
             )
             for bamfile, chromosome, start, stop, positions, barcode_handler in jobs
         )

--- a/demuxalot/snp_detection.py
+++ b/demuxalot/snp_detection.py
@@ -28,6 +28,7 @@ def detect_snps_for_chromosome(
         minimum_alternative_coverage: int,
         max_snp_candidates: int = 10000,
         minimum_fraction_of_ref_and_alt=0.98,
+        **kwargs
 ):
     # stage1. straightforward counting, to detect possible candidates for snp
     coverage = 0
@@ -37,7 +38,7 @@ def detect_snps_for_chromosome(
             # size = 4 x positions (first axis enumerates "ACTG"))
             coverage = coverage + np.asarray(
                 bamfile.count_coverage(chromosome, start=start, stop=stop,
-                                       read_callback=lambda read: parse_read(read) is not None),
+                                       read_callback=lambda read: parse_read(read, **kwargs) is not None),
                 dtype="int32"
             )
 
@@ -65,6 +66,7 @@ def detect_snps_for_chromosome(
         parse_read=parse_read,
         joblib_n_jobs=None,  # we are already inside joblib job
         joblib_verbosity=0,
+        **kwargs
     )
     if len(compressed_snp_calls) == 0:
         return []
@@ -142,6 +144,7 @@ def detect_snps_positions(
         ignore_known_snps=True,
         max_fragment_step=10_000_000,
         joblib_verbosity=11,
+        **kwargs
 ):
     """
     Detects SNPs based on data.
@@ -155,6 +158,7 @@ def detect_snps_positions(
         joblib_n_jobs=joblib_n_jobs,
         parse_read=parse_read,
         joblib_verbosity=joblib_verbosity,
+        **kwargs
     )
 
     _likelihoods, posterior_probabilities = Demultiplexer.predict_posteriors(
@@ -190,6 +194,7 @@ def detect_snps_positions(
                 minimum_alternative_fraction=minimum_alternative_fraction,
                 barcode_handler=barcode_handler,
                 regularization=regularization,
+                **kwargs
             )
             for chromosome, length in chromosomes
             for start in range(0, length, max_fragment_step)


### PR DESCRIPTION
While cellranger uses the `UB` SAM tag, other scRNA-seq analyses use different SAM tags (*e.g.* `XM`) for the same information. By parameterizing the existing `parse_read` function, this (and other read parsing/filtering options) can be adjusted by the caller without the need for boilerplate code required for a custom callback class. At the same time, by providing the previously hard-coded values as default parameters, compatibility with existing code is kept. All functions using this callback have been extended by optional keyword arguments to allow passing through the newly added parameters.

This addresses one out of two issues raised in https://github.com/herophilus/demuxalot/issues/23.